### PR TITLE
Revert "Extend files limit"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21392,7 +21392,7 @@ const getPullRequestData = (octokit, variables) => __awaiter(void 0, void 0, voi
     query ($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $pullRequestNumber) {
-          files(first: 10000) {
+          files(first: 100) {
             nodes {
               path
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scs-action",
-  "version": "4.2.6",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scs-action",
-      "version": "4.2.6",
+      "version": "4.2.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scs-action",
-  "version": "4.2.6",
+  "version": "4.2.5",
   "private": false,
   "author": "Artur Sharapov",
   "license": "MIT",

--- a/src/requests/pull-request-data.ts
+++ b/src/requests/pull-request-data.ts
@@ -9,7 +9,7 @@ export const getPullRequestData = async (
     query ($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $pullRequestNumber) {
-          files(first: 10000) {
+          files(first: 100) {
             nodes {
               path
             }


### PR DESCRIPTION
Reverts qaip/scs-action#48

**Requesting 10000 records on the `files` connection exceeds the `first` limit of 100 records.**
Souece: https://github.com/qaip/gt/actions/runs/5038208275/jobs/9035539219
